### PR TITLE
Fix NameError in choose_bg_color when color picker is cancelled

### DIFF
--- a/markdown_reader/ui.py
+++ b/markdown_reader/ui.py
@@ -858,10 +858,10 @@ class MarkdownReader:
         if color:
             color = color.hex
             text_area = self.get_current_text_area()
-        if text_area:
-            text_area.config(bg=color)
-            self.current_bg_color = color
-            self.update_preview()
+            if text_area:
+                text_area.config(bg=color)
+                self.current_bg_color = color
+                self.update_preview()
             
 
     def update_preview(self):


### PR DESCRIPTION
## Summary

- **Bug**: Cancelling the background color picker dialog causes a `NameError` crash because `text_area` is only defined inside the `if color:` block but referenced outside it on the next line.
- **Fix**: Nest the `text_area` check inside the `if color:` block, matching the pattern already used by `choose_fg_color()`.

## Before (buggy)
```python
if color:
    color = color.hex
    text_area = self.get_current_text_area()
if text_area:  # NameError if color is None
    text_area.config(bg=color)
```

## After (fixed)
```python
if color:
    color = color.hex
    text_area = self.get_current_text_area()
    if text_area:
        text_area.config(bg=color)
        self.current_bg_color = color
        self.update_preview()
```

## Test plan
- [ ] Open the app, go to background color picker, cancel the dialog — should no longer crash
- [ ] Choose a valid color — should still apply correctly