### PR TITLE
Fix background color dialog not showing current color

### DIFF
--- a/markdown_reader/ui.py
+++ b/markdown_reader/ui.py
@@ -852,7 +852,7 @@ class MarkdownReader:
             
 
     def choose_bg_color(self):
-        cd = dialogs.ColorChooserDialog()
+        cd = dialogs.ColorChooserDialog(initialcolor=self.current_bg_color)
         cd.show()
         color = cd.result
         if color:


### PR DESCRIPTION
Fix background color dialog initialization

The ColorChooserDialog was opening without displaying the current
background color. This change initializes the dialog with the
current editor background color using `initialcolor`.

This improves UX by keeping color selection consistent with
the editor state.