### PR TITLE
docs: fix typo in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Markdown Reader is a clean and intuitive Markdown reader with real-time preview 
 
 ## How to Get Started
 
-1. Fork the repogit
+1. Fork the repository
 ![fork](image.png)
 2. Clone the repo
 ```bash


### PR DESCRIPTION
This PR fixes a small typo in CONTRIBUTING.md.

While investigating why my previous merged PR was not reflecting in the contributor list, I noticed this minor documentation issue and decided to correct it.