### PR TITLE
Fix preview rendering issue for paypal_payments section

### DIFF
--- a/markdown_reader/logic.py
+++ b/markdown_reader/logic.py
@@ -1061,6 +1061,10 @@ def _is_probably_math_token(token):
     core = token.strip()
     core = core.strip("'\".,;:!?")
 
+    # Never treat inline-code fragments as math.
+    if '`' in core:
+        return False
+
     if _looks_like_url_or_path(core):
         return False
     


### PR DESCRIPTION
Fixed.

Cause of the Issue:
The input was a code snippet enclosed in backticks (for example, "paypal_payments").
During the preprocessing stage, it was interpreted as mathematical content by MathJax, which led to incorrect rendering in the browser preview.