### PR TITLE
docs: updated title of documentation site

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: My Docs
+site_name: Markdown Reader Docs
 theme:
   name: material  
 


### PR DESCRIPTION
Changed the title of the documentation site from `My Docs` to `Markdown Reader Docs`