### PR TITLE
implement AI translation feature and fixed previous endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 
 import os
 import sys
+from dotenv import load_dotenv
+load_dotenv()
 
 # Ensure the project root is importable
 _ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -216,7 +216,6 @@ def automation_logs(limit: int = 100):
 
 @router.post("/translate")
 def translate(payload: TranslatePayload):
-    """Translate Markdown content via AI."""
     try:
         result = translate_markdown_with_ai(
             payload.content, payload.source_language, payload.target_language
@@ -224,11 +223,14 @@ def translate(payload: TranslatePayload):
     except TranslationConfigError as exc:
         raise HTTPException(
             status_code=422,
-            detail={
-                "message": str(exc),
-                "provider": getattr(exc, "provider_name", None),
-            },
+            detail={"message": str(exc), "provider": getattr(exc, "provider_name", None)},
         )
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc))
+
+    if isinstance(result, tuple):
+        result = result[0]
+    if isinstance(result, dict):
+        result = result.get("translated_markdown") or result.get("translated") or str(result)
+
     return {"translated": result}

--- a/frontend/src/components/AIPanel.tsx
+++ b/frontend/src/components/AIPanel.tsx
@@ -1,11 +1,5 @@
 "use client";
 
-/**
- * AIPanel.tsx
- * ===========
- * Slide-in AI assistant panel.
- */
-
 import { useState, useRef, useEffect } from "react";
 import { useAIChat } from "@/hooks/useAIChat";
 
@@ -15,9 +9,22 @@ type Props = {
   onApplyAction?: (type: string, content: string) => void;
 };
 
+const LANGUAGES = [
+  "Auto Detect", "English", "Chinese", "Spanish", "French", "German",
+  "Japanese", "Korean", "Portuguese", "Russian", "Arabic", "Hindi",
+  "Italian", "Dutch", "Polish", "Turkish",
+];
+
+type Tab = "chat" | "translate";
+
 export default function AIPanel({ documentText, selectedText = "", onApplyAction }: Props) {
-  const { messages, loading, error, sendMessage, clearHistory } = useAIChat();
+  const { messages, loading, error, sendMessage, translate, clearHistory } = useAIChat();
+  const [tab, setTab] = useState<Tab>("chat");
   const [input, setInput] = useState("");
+  const [sourceLang, setSourceLang] = useState("Auto Detect");
+  const [targetLang, setTargetLang] = useState("English");
+  const [translateScope, setTranslateScope] = useState<"selection" | "document">("document");
+  const [translatedPreview, setTranslatedPreview] = useState<string | null>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -32,89 +39,206 @@ export default function AIPanel({ documentText, selectedText = "", onApplyAction
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === "Enter" && !e.shiftKey) {
-      e.preventDefault();
-      handleSend();
+    if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); handleSend(); }
+  };
+
+  const handleTranslate = async () => {
+    const content = translateScope === "selection" && selectedText ? selectedText : documentText;
+    if (!content.trim()) return;
+    setTranslatedPreview(null);
+    const result = await translate(content, sourceLang === "Auto Detect" ? "auto" : sourceLang, targetLang);
+    if (result) setTranslatedPreview(result);
+  };
+
+  const applyTranslation = (type: "replace_document" | "replace_selection") => {
+    if (translatedPreview && onApplyAction) {
+      onApplyAction(type, translatedPreview);
+      setTranslatedPreview(null);
+    }
+  };
+
+  const insertBelow = () => {
+    if (translatedPreview && onApplyAction) {
+      onApplyAction("insert_below", translatedPreview);
+      setTranslatedPreview(null);
     }
   };
 
   return (
     <div className="flex flex-col w-80 min-w-[280px] max-w-[380px] border-l border-gray-200 dark:border-gray-700 bg-white dark:bg-[#1e1e1e] text-sm">
-      {/* Header */}
       <div className="flex items-center justify-between px-3 py-2 border-b border-gray-200 dark:border-gray-700 shrink-0">
-        <span className="font-semibold text-gray-700 dark:text-gray-200">AI Assistant</span>
-        <button
-          onClick={clearHistory}
-          className="text-xs text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
-          title="Clear history"
-        >
-          Clear
-        </button>
-      </div>
-
-      {/* Messages */}
-      <div className="flex-1 overflow-y-auto p-3 space-y-3">
-        {messages.length === 0 && (
-          <p className="text-gray-400 dark:text-gray-500 text-xs">
-            Ask me to summarize, generate a TOC, translate, fix code blocks, or anything else…
-          </p>
-        )}
-        {messages.map((msg) => (
-          <div key={msg.id} className={`flex flex-col gap-1 ${msg.role === "user" ? "items-end" : "items-start"}`}>
-            <div
-              className={`px-3 py-2 rounded-lg text-xs max-w-full whitespace-pre-wrap break-words ${
-                msg.role === "user"
+        <div className="flex gap-1">
+          {(["chat", "translate"] as Tab[]).map((t) => (
+            <button
+              key={t}
+              onClick={() => setTab(t)}
+              className={`px-2 py-0.5 rounded text-xs font-medium capitalize ${
+                tab === t
                   ? "bg-blue-500 text-white"
-                  : "bg-gray-100 dark:bg-[#2d2d2d] text-gray-800 dark:text-gray-100"
+                  : "text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
               }`}
             >
-              {msg.content}
-            </div>
-            {msg.proposedAction && msg.proposedAction.type !== "none" && onApplyAction && (
-              <button
-                onClick={() => onApplyAction(msg.proposedAction!.type, msg.proposedAction!.content)}
-                className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
-              >
-                ✅ Apply: {msg.proposedAction.type === "replace_document" ? "Replace document" : "Replace selection"}
-              </button>
-            )}
-          </div>
-        ))}
-        {loading && (
-          <div className="flex items-start">
-            <div className="px-3 py-2 rounded-lg text-xs bg-gray-100 dark:bg-[#2d2d2d] text-gray-500">
-              Thinking…
-            </div>
-          </div>
+              {t}
+            </button>
+          ))}
+        </div>
+        {tab === "chat" && (
+          <button
+            onClick={clearHistory}
+            className="text-xs text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+          >
+            Clear
+          </button>
         )}
-        {error && (
-          <div className="text-xs text-red-500 bg-red-50 dark:bg-red-900/20 px-2 py-1 rounded">
-            {error}
-          </div>
-        )}
-        <div ref={bottomRef} />
       </div>
 
-      {/* Input */}
-      <div className="border-t border-gray-200 dark:border-gray-700 p-2 shrink-0">
-        <div className="flex gap-1">
-          <textarea
-            value={input}
-            onChange={(e) => setInput(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder="Ask AI… (Enter to send, Shift+Enter for newline)"
-            rows={3}
-            className="flex-1 resize-none text-xs p-2 border border-gray-200 dark:border-gray-600 rounded bg-gray-50 dark:bg-[#2d2d2d] text-gray-800 dark:text-gray-100 focus:outline-none focus:border-blue-400"
-          />
+      {tab === "chat" ? (
+        <>
+          <div className="flex-1 overflow-y-auto p-3 space-y-3">
+            {messages.length === 0 && (
+              <p className="text-gray-400 dark:text-gray-500 text-xs">
+                Ask me to summarize, generate a TOC, translate, fix code blocks, or anything else…
+              </p>
+            )}
+            {messages.map((msg) => (
+              <div key={msg.id} className={`flex flex-col gap-1 ${msg.role === "user" ? "items-end" : "items-start"}`}>
+                <div
+                  className={`px-3 py-2 rounded-lg text-xs max-w-full whitespace-pre-wrap break-words ${
+                    msg.role === "user"
+                      ? "bg-blue-500 text-white"
+                      : "bg-gray-100 dark:bg-[#2d2d2d] text-gray-800 dark:text-gray-100"
+                  }`}
+                >
+                  {msg.content}
+                </div>
+                {msg.proposedAction && msg.proposedAction.type !== "none" && onApplyAction && (
+                  <button
+                    onClick={() => onApplyAction(msg.proposedAction!.type, msg.proposedAction!.content)}
+                    className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+                  >
+                    ✅ Apply: {msg.proposedAction.type === "replace_document" ? "Replace document" : "Replace selection"}
+                  </button>
+                )}
+              </div>
+            ))}
+            {loading && (
+              <div className="flex items-start">
+                <div className="px-3 py-2 rounded-lg text-xs bg-gray-100 dark:bg-[#2d2d2d] text-gray-500">Thinking…</div>
+              </div>
+            )}
+            {error && (
+              <div className="text-xs text-red-500 bg-red-50 dark:bg-red-900/20 px-2 py-1 rounded">{error}</div>
+            )}
+            <div ref={bottomRef} />
+          </div>
+          <div className="border-t border-gray-200 dark:border-gray-700 p-2 shrink-0">
+            <div className="flex gap-1">
+              <textarea
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder="Ask AI… (Enter to send, Shift+Enter for newline)"
+                rows={3}
+                className="flex-1 resize-none text-xs p-2 border border-gray-200 dark:border-gray-600 rounded bg-gray-50 dark:bg-[#2d2d2d] text-gray-800 dark:text-gray-100 focus:outline-none focus:border-blue-400"
+              />
+              <button
+                onClick={handleSend}
+                disabled={loading || !input.trim()}
+                className="px-2 self-end py-1.5 text-xs bg-blue-500 text-white rounded hover:bg-blue-600 disabled:opacity-40"
+              >
+                Send
+              </button>
+            </div>
+          </div>
+        </>
+      ) : (
+        <div className="flex-1 overflow-y-auto p-3 flex flex-col gap-3">
+          <div className="flex flex-col gap-1">
+            <label className="text-xs text-gray-500 dark:text-gray-400">Translate</label>
+            <div className="flex gap-1">
+              {(["document", "selection"] as const).map((s) => (
+                <button
+                  key={s}
+                  onClick={() => setTranslateScope(s)}
+                  disabled={s === "selection" && !selectedText}
+                  className={`flex-1 py-1 text-xs rounded border ${
+                    translateScope === s
+                      ? "bg-blue-500 text-white border-blue-500"
+                      : "border-gray-200 dark:border-gray-600 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-[#2d2d2d]"
+                  } disabled:opacity-30`}
+                >
+                  {s === "document" ? "Full Document" : "Selection"}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <label className="text-xs text-gray-500 dark:text-gray-400">From</label>
+            <select
+              value={sourceLang}
+              onChange={(e) => setSourceLang(e.target.value)}
+              className="text-xs p-1.5 border border-gray-200 dark:border-gray-600 rounded bg-gray-50 dark:bg-[#2d2d2d] text-gray-800 dark:text-gray-100"
+            >
+              {LANGUAGES.map((l) => <option key={l}>{l}</option>)}
+            </select>
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <label className="text-xs text-gray-500 dark:text-gray-400">To</label>
+            <select
+              value={targetLang}
+              onChange={(e) => setTargetLang(e.target.value)}
+              className="text-xs p-1.5 border border-gray-200 dark:border-gray-600 rounded bg-gray-50 dark:bg-[#2d2d2d] text-gray-800 dark:text-gray-100"
+            >
+              {LANGUAGES.filter((l) => l !== "Auto Detect").map((l) => <option key={l}>{l}</option>)}
+            </select>
+          </div>
+
           <button
-            onClick={handleSend}
-            disabled={loading || !input.trim()}
-            className="px-2 self-end py-1.5 text-xs bg-blue-500 text-white rounded hover:bg-blue-600 disabled:opacity-40"
+            onClick={handleTranslate}
+            disabled={loading || !documentText.trim()}
+            className="py-1.5 text-xs bg-blue-500 text-white rounded hover:bg-blue-600 disabled:opacity-40"
           >
-            Send
+            {loading ? "Translating…" : "Translate"}
           </button>
+
+          {error && (
+            <div className="text-xs text-red-500 bg-red-50 dark:bg-red-900/20 px-2 py-1 rounded">{error}</div>
+          )}
+
+          {translatedPreview && (
+            <div className="flex flex-col gap-2">
+              <div className="text-xs text-gray-500 dark:text-gray-400 font-medium">Preview</div>
+              <div className="text-xs bg-gray-50 dark:bg-[#2d2d2d] border border-gray-200 dark:border-gray-600 rounded p-2 max-h-48 overflow-y-auto whitespace-pre-wrap text-gray-800 dark:text-gray-100">
+                {translatedPreview}
+              </div>
+              <div className="flex flex-col gap-1">
+                <button
+                  onClick={() => applyTranslation("replace_document")}
+                  className="py-1 text-xs bg-green-500 text-white rounded hover:bg-green-600"
+                >
+                  Replace Document
+                </button>
+                {selectedText && (
+                  <button
+                    onClick={() => applyTranslation("replace_selection")}
+                    className="py-1 text-xs bg-yellow-500 text-white rounded hover:bg-yellow-600"
+                  >
+                    Replace Selection
+                  </button>
+                )}
+                <button
+                  onClick={insertBelow}
+                  className="py-1 text-xs border border-gray-300 dark:border-gray-600 rounded hover:bg-gray-50 dark:hover:bg-[#2d2d2d] text-gray-700 dark:text-gray-300"
+                >
+                  Insert Below
+                </button>
+              </div>
+            </div>
+          )}
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/hooks/useAIChat.ts
+++ b/frontend/src/hooks/useAIChat.ts
@@ -20,25 +20,15 @@ export function useAIChat() {
   const [error, setError] = useState<string | null>(null);
 
   const sendMessage = useCallback(
-    async (
-      userMessage: string,
-      documentText = "",
-      selectedText = ""
-    ) => {
+    async (userMessage: string, documentText = "", selectedText = "") => {
       if (!userMessage.trim()) return;
 
-      const userMsg: ChatMessage = {
-        id: msgId(),
-        role: "user",
-        content: userMessage,
-      };
-
+      const userMsg: ChatMessage = { id: msgId(), role: "user", content: userMessage };
       setMessages((prev) => [...prev, userMsg]);
       setLoading(true);
       setError(null);
 
       const history = messages.map((m) => ({ role: m.role, content: m.content }));
-
       const payload: AgentChatPayload = {
         message: userMessage,
         document_text: documentText,
@@ -58,8 +48,7 @@ export function useAIChat() {
         setMessages((prev) => [...prev, assistantMsg]);
         return result;
       } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        setError(msg);
+        setError(err instanceof Error ? err.message : String(err));
       } finally {
         setLoading(false);
       }
@@ -67,10 +56,44 @@ export function useAIChat() {
     [messages]
   );
 
+  const translate = useCallback(
+    async (
+      content: string,
+      sourceLang: string,
+      targetLang: string
+    ): Promise<string | null> => {
+      setLoading(true);
+      setError(null);
+      const userMsg: ChatMessage = {
+        id: msgId(),
+        role: "user",
+        content: `Translate ${sourceLang === "auto" ? "" : `from ${sourceLang} `}to ${targetLang}:\n\n${content.slice(0, 120)}${content.length > 120 ? "…" : ""}`,
+      };
+      setMessages((prev) => [...prev, userMsg]);
+      try {
+        const result = await AI.translate(content, sourceLang, targetLang);
+        const assistantMsg: ChatMessage = {
+          id: msgId(),
+          role: "assistant",
+          content: `Translation complete (→ ${targetLang}).`,
+          proposedAction: { type: "replace_document", content: result.translated, reason: "translated" },
+        };
+        setMessages((prev) => [...prev, assistantMsg]);
+        return result.translated;
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+        return null;
+      } finally {
+        setLoading(false);
+      }
+    },
+    []
+  );
+
   const clearHistory = useCallback(() => {
     setMessages([]);
     setError(null);
   }, []);
 
-  return { messages, loading, error, sendMessage, clearHistory };
+  return { messages, loading, error, sendMessage, translate, clearHistory };
 }


### PR DESCRIPTION
Closes #169

## Changes
- `backend/main.py` : added `load_dotenv()` for env var support
- `backend/routers/ai.py` : fixed translate endpoint to unpack tuple return
- `frontend/src/components/AIPanel.tsx` : added Translate tab with language dropdowns, preview and apply buttons
- `frontend/src/hooks/useAIChat.ts` : added `translate()` function