### PR TITLE
ci: add multi-OS desktop release workflow (macOS Intel, Linux, Windows)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,118 @@
+name: Release desktop builds
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  # Next.js must emit a static export so Tauri can bundle ../out
+  NEXT_EXPORT: "1"
+
+jobs:
+  build:
+    name: ${{ matrix.platform }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: macOS (Apple Silicon)
+            os: macos-14
+            target: aarch64-apple-darwin
+            bin-ext: ""
+          - platform: macOS (Intel)
+            os: macos-13
+            target: x86_64-apple-darwin
+            bin-ext: ""
+          - platform: Linux (x86_64)
+            os: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
+            bin-ext: ""
+          - platform: Windows (x86_64)
+            os: windows-latest
+            target: x86_64-pc-windows-msvc
+            bin-ext: ".exe"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Linux system dependencies
+        if: matrix.os == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            build-essential \
+            curl wget file \
+            libssl-dev \
+            libgtk-3-dev \
+            libxdo-dev \
+            libpango-1.0-0 \
+            libpangocairo-1.0-0 \
+            libgdk-pixbuf-2.0-0 \
+            libcairo2 \
+            libffi-dev
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache cargo registry and build
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: frontend/src-tauri -> target
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install Python
+        run: uv python install
+
+      - name: Build backend sidecar
+        run: |
+          uv sync --frozen
+          uv run pyinstaller markdown-reader-backend.spec
+
+      - name: Stage sidecar with target triple
+        shell: bash
+        run: |
+          mkdir -p frontend/src-tauri/binaries
+          src="dist/markdown-reader-backend${{ matrix.bin-ext }}"
+          dest="frontend/src-tauri/binaries/markdown-reader-backend-${{ matrix.target }}${{ matrix.bin-ext }}"
+          cp "$src" "$dest"
+          chmod +x "$dest" || true
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Build and release
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          projectPath: frontend
+          tagName: ${{ github.ref_name }}
+          releaseName: "Markdown Reader ${{ github.ref_name }}"
+          releaseDraft: true
+          prerelease: false
+          args: --target ${{ matrix.target }}

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ release-artifacts/
 # Keep unrelated local workflow drafts out of status while tracking the Pages workflow.
 .github/workflows/*
 !.github/workflows/deploy-distribution.yml
+!.github/workflows/release.yml

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,6 +22,7 @@
         "@types/react": "18.3.28",
         "@types/react-dom": "^18.3.0",
         "autoprefixer": "^10.4.0",
+        "cross-env": "^10.1.0",
         "eslint": "^8.57.0",
         "eslint-config-next": "^14.2.0",
         "postcss": "^8.4.0",
@@ -75,6 +76,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
@@ -2048,6 +2056,24 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "@types/react": "18.3.28",
     "@types/react-dom": "^18.3.0",
     "autoprefixer": "^10.4.0",
+    "cross-env": "^10.1.0",
     "eslint": "^8.57.0",
     "eslint-config-next": "^14.2.0",
     "postcss": "^8.4.0",

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
     "frontendDist": "../out",
     "devUrl": "http://localhost:3000",
     "beforeDevCommand": "npm run dev",
-    "beforeBuildCommand": "NEXT_EXPORT=1 npm run build"
+    "beforeBuildCommand": "cross-env NEXT_EXPORT=1 npm run build"
   },
   "app": {
     "windows": [


### PR DESCRIPTION
## What

Adds a GitHub Actions workflow (`.github/workflows/release.yml`) that builds and publishes desktop bundles for every major platform on tag push, addressing #193 (currently only the macOS Apple Silicon download is offered).

Build matrix:

| Platform | Runner | Target triple | Bundles |
| --- | --- | --- | --- |
| macOS (Apple Silicon) | `macos-14` | `aarch64-apple-darwin` | `.app` / `.dmg` |
| macOS (Intel) | `macos-13` | `x86_64-apple-darwin` | `.app` / `.dmg` |
| Linux (x86_64) | `ubuntu-22.04` | `x86_64-unknown-linux-gnu` | `.deb` / `.AppImage` / `.rpm` |
| Windows (x86_64) | `windows-latest` | `x86_64-pc-windows-msvc` | `.msi` / `.exe` |

## How it works

Each target runs on a **native runner**, because the FastAPI backend is bundled with PyInstaller, which cannot cross-compile. For each platform the job:

1. installs the Tauri system dependencies (Linux only) plus the Pango/Cairo libraries WeasyPrint needs;
2. builds the backend with `uv sync --frozen` + `pyinstaller markdown-reader-backend.spec`;
3. renames the sidecar to `markdown-reader-backend-<target-triple>` (the name Tauri's `externalBin` resolves per target);
4. runs `tauri-action`, which builds the app and uploads the bundles to a **draft** GitHub release.

Triggered on `v*` tags (and `workflow_dispatch`). The release is created as a draft so it can be reviewed before publishing.

## Note on the `cross-env` change

`beforeBuildCommand` used the shell-only form `NEXT_EXPORT=1 npm run build`, which fails on the Windows runner (cmd does not understand the `VAR=value cmd` prefix). I switched it to `cross-env NEXT_EXPORT=1 npm run build` and added `cross-env` as a dev dependency. This keeps the macOS/Linux behaviour identical and unblocks the Windows build.

## Notes

- `ubuntu-22.04` is pinned on purpose: it ships WebKitGTK 4.1 cleanly, whereas 24.04 changed the packaging.
- Public macOS builds will still need Developer ID signing/notarization to clear Gatekeeper (same as the existing `scripts/package-macos-release.sh`); that can be layered on with secrets later.
- I was not able to run the full matrix from a fork without the workflow being enabled upstream, so a maintainer review of the runner behaviour on first tag is welcome.

Closes #193
