### PR TITLE
docs: refresh contributor guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,38 +1,211 @@
 # Contributing to Markdown Reader
 
-Thank you for your interest in contributing to **Markdown Reader**! We welcome contributions of all kinds, including bug reports, feature suggestions, pull requests, and documentation improvements.
+Thank you for your interest in contributing to **Markdown Reader**. Contributions
+are welcome, including bug reports, focused feature improvements, tests,
+documentation updates, and developer-experience fixes.
 
 ---
 
 ## About the Project
 
-Markdown Reader is a clean and intuitive Markdown reader with real-time preview support, dark mode toggle, and drag-and-drop file opening. It is compatible with macOS and Windows desktop environments and built with pure Python and Tkinter.
+Markdown Reader is a desktop Markdown editor and reader with:
+
+- a FastAPI backend in `backend/`
+- a Next.js frontend and Tauri desktop shell in `frontend/`
+- legacy Tkinter app code preserved in `markdown_reader/`
+- Python tests in `tests/`
+- project notes in `docs/`
+- release and distribution workflows in `.github/workflows/`
+
+The current development app runs a local FastAPI backend on
+`http://127.0.0.1:8000` and launches the Tauri desktop shell with a Next.js
+frontend on `http://localhost:3000`.
 
 ---
 
-## How to Get Started
+## Prerequisites
 
-1. Fork the repository
-2. Clone the repository
+- Python 3.11 or newer
+- [uv](https://docs.astral.sh/uv/) for Python dependency management
+- Node.js 18 or newer and npm for the frontend
+- Rust and the Tauri prerequisites for desktop-shell or packaging work
+
+Docs-only changes usually do not require a full desktop build.
+
+---
+
+## Get Started
+
+1. Fork and clone the repository.
+
 ```bash
 git clone https://github.com/(your-user-name)/markdown-reader.git
 cd markdown-reader
 ```
-3. Create a new branch
+
+2. Create a focused branch.
+
 ```bash
-git checkout -b <new-branch>
+git checkout -b <short-description>
 ```
-4. Change the code
-5. Commit the changes
-6. Push
+
+3. Install Python and frontend dependencies.
+
+```bash
+uv sync --extra dev
+cd frontend && npm install && cd ..
+```
+
+4. Configure the frontend environment file.
+
+```bash
+cp frontend/.env.local.example frontend/.env.local
+```
+
+5. Install pre-commit hooks if you plan to commit locally.
+
+```bash
+uv run pre-commit install
+```
+
+---
+
+## Local Development
+
+Use the project helper for normal desktop development:
+
+```bash
+./scripts/dev-tauri.sh
+```
+
+This starts the FastAPI backend and launches the Tauri desktop shell. The
+backend API docs are available during development at:
+
+- Swagger: `http://127.0.0.1:8000/docs`
+- ReDoc: `http://127.0.0.1:8000/redoc`
+
+You can also run services separately when debugging. Use separate terminals for
+long-running commands:
+
+```bash
+# Terminal 1: backend
+uv run uvicorn backend.main:app --host 127.0.0.1 --port 8000 --reload
+
+# Terminal 2: frontend dev server
+cd frontend && npm run dev
+
+# Terminal 3: Tauri shell, with the frontend dev server already running
+cd frontend && npm run tauri:dev
+```
+
+AI-provider features may ask for API keys in the app, but normal documentation,
+test, backend, frontend, and onboarding contributions should not require API
+keys, secrets, paid services, or authenticated external services.
+
+---
+
+## Validation Checklist
+
+Run the checks that match the files you changed.
+
+### Documentation-only changes
+
+```bash
+git diff --check
+```
+
+For link or wording updates, also search for stale references that your change
+may affect:
+
+```bash
+rg -n "old text|old command|old path" README.MD CONTRIBUTING.md docs
+```
+
+### Python backend or legacy Python changes
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run python -m unittest discover -s tests
+```
+
+To run one test file:
+
+```bash
+uv run python -m unittest tests/test_ai_automation_logic.py
+```
+
+### Frontend changes
+
+```bash
+cd frontend
+npm run build
+```
+
+If a frontend lint command is available in your environment, run it as well:
+
+```bash
+cd frontend
+npm run lint
+```
+
+### Desktop or packaging changes
+
+For Tauri or release packaging work, first check the relevant files:
+
+- `frontend/src-tauri/tauri.conf.json`
+- `frontend/src-tauri/Cargo.toml`
+- `markdown-reader-backend.spec`
+- `.github/workflows/release.yml`
+- `scripts/dev-tauri.sh`
+
+Then run the smallest local check that proves your change. Full desktop builds
+can require platform-specific system packages, so mention any environment gaps
+in your pull request.
+
+---
+
+## Docs-Only Contributions
+
+Docs changes are valuable when they make setup, validation, user workflows, or
+project architecture easier to understand. Keep them practical:
+
+- update stale commands or paths
+- align docs with `README.MD`, `pyproject.toml`, `frontend/package.json`, and
+  Tauri config
+- add concise troubleshooting notes when you have verified them locally
+- avoid broad wording-only rewrites unless the issue specifically asks for one
+
+For broad tracking issues such as `#187`, keep each pull request small and
+focused. Prefer one clear improvement, such as contributor onboarding, a setup
+note, a feature explanation, a validation checklist, or a small example file.
+
+---
+
+## Issue and Pull Request Etiquette
+
+- Check open issues and pull requests before starting to avoid duplicate work.
+- Keep one pull request focused on one problem.
+- Describe what changed, why it helps, and how you validated it.
+- Include screenshots only when the change affects visible UI or distribution
+  pages.
+- Do not include secrets, API keys, tokens, or personal credentials in issues,
+  commits, logs, screenshots, or pull requests.
+- If your change cannot be fully validated locally, explain what you did test
+  and what remains unverified.
+
+After review, push your branch and open a pull request from your fork:
+
 ```bash
 git push origin <new-branch>
 ```
-7. Create a pull request
 
-## Code Documentation Guidlines
+---
 
-When creating or updating a .py function, please follow the following guidelines for documenting the function:
+## Code Documentation Guidelines
+
+When creating or updating a Python function, please use clear docstrings for
+non-obvious behavior, public helpers, or code paths that are easy to misuse:
 
 ```python
 """


### PR DESCRIPTION
## Summary

- Refreshes CONTRIBUTING.md to match the current FastAPI, Next.js, and Tauri project structure.
- Adds contributor prerequisites, setup steps, local development workflow, and validation guidance by change type.
- Adds docs-only contribution guidance, no-secret/API-key expectations, and issue/PR etiquette.
- Notes that broad #187 contributions should stay small and focused.

## Validation

- `git diff --check HEAD~1..HEAD`
- `rg -n "pure Python and Tkinter|Guidlines|python app.py|Python >= 3.10|python-ci.yml|doc/" CONTRIBUTING.md || true`

## Scope note

This PR is intentionally focused on `CONTRIBUTING.md` only. It does not broaden into README wording polish, `docs/index.md`, or document outline / TOC functionality.

Refs #187