### PR TITLE
feat: Implemented Notion-style slash commands to the editor

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -34,6 +34,7 @@ Most modern writing apps force you to choose between **privacy** and **power**. 
 - 🔒 **Local-First Architecture**: Your files never leave your machine unless you explicitly call an external AI API.
 - 🤖 **Bring-Your-Own-AI**: Configure OpenAI, Anthropic, or OpenRouter with your own API keys.
 - ✍️ **Intelligent Editing**: AI-assisted translation, summarization, formatting, and code-block cleanup.
+- ⚡ **Slash Commands**: Type `/` in the editor to trigger AI actions or insert a table inline, without opening the AI panel.
 - 🛡️ **Audit & Rollback**: Review all AI suggestions before applying them. Reject or rollback changes with a single click.
 - 🖥️ **Native Desktop Feel**: Built with Next.js and packaged with Tauri for blazing-fast performance.
 
@@ -84,6 +85,23 @@ Markdown Reader is split into three main layers to ensure maximum performance an
 1. **Backend (`/backend`)**: A blazing-fast FastAPI application handling rendering, export, and all AI API communications.
 2. **Frontend (`/frontend`)**: A Next.js UI providing the rich editor experience, packaged within a Tauri desktop shell.
 When packaged for desktop use, the Python backend is bundled as a silent Tauri sidecar process, dynamically assigning ports at runtime to avoid conflicts.
+
+---
+
+## ⚡ Slash Commands
+
+Type `/` at the start of a line (or after whitespace) in the editor to open an inline command menu:
+
+| Command | Behavior |
+| --- | --- |
+| `/summarize` | Summarizes the document via AI |
+| `/translate` | Opens the AI panel's Translate tab |
+| `/format` | Applies Markdown formatting via AI |
+| `/toc` | Generates a table of contents via AI |
+| `/fix-code` | Fixes code block fences via AI |
+| `/insert-table` | Inserts a Markdown table (no AI call) |
+
+Use the arrow keys to navigate, Enter to run a command, or Escape to dismiss the menu.
 
 ---
 

--- a/backend/ai_logic.py
+++ b/backend/ai_logic.py
@@ -152,6 +152,14 @@ def get_ai_provider_env_var(provider: str) -> str:
     }[provider]
 
 
+def _get_key_slot_env_var(provider_or_slot: str) -> str:
+    provider_or_slot = (provider_or_slot or "").strip()
+    for choice in OPENAI_COMPATIBLE_BASE_URL_OPTIONS:
+        if provider_or_slot == get_openai_compatible_storage_key_name(choice):
+            return get_openai_compatible_env_var(choice)
+    return get_ai_provider_env_var(provider_or_slot)
+
+
 def get_ai_provider_display_name(provider: str) -> str:
     return {
         "openai_compatible": "OpenAI Compatible",
@@ -226,16 +234,34 @@ def get_openai_compatible_env_var(choice_key: str | None = None) -> str:
 def get_ai_provider_model(provider: str) -> str:
     provider = _normalize_provider_name(provider)
     env_var = AI_PROVIDER_MODEL_ENV[provider]
-    return os.getenv(env_var, "").strip() or get_provider_default_models(provider)[0]
+    settings_model = ""
+    ai_models = _load_app_settings().get("ai_models", {})
+    if isinstance(ai_models, dict):
+        settings_model = str(ai_models.get(provider, "")).strip()
+    return (
+        os.getenv(env_var, "").strip()
+        or settings_model
+        or get_provider_default_models(provider)[0]
+    )
 
 
 def set_ai_provider_model(provider: str, model: str) -> None:
     provider = _normalize_provider_name(provider)
-    os.environ[AI_PROVIDER_MODEL_ENV[provider]] = model.strip()
+    model = model.strip()
+    os.environ[AI_PROVIDER_MODEL_ENV[provider]] = model
+    settings = _load_app_settings()
+    settings.setdefault("ai_models", {})
+    if isinstance(settings["ai_models"], dict):
+        settings["ai_models"][provider] = model
+    _save_app_settings(settings)
 
 
 def set_current_ai_provider(provider: str) -> None:
-    os.environ["AI_PROVIDER"] = _normalize_provider_name(provider)
+    provider = _normalize_provider_name(provider)
+    os.environ["AI_PROVIDER"] = provider
+    settings = _load_app_settings()
+    settings["ai_provider"] = provider
+    _save_app_settings(settings)
 
 
 def get_provider_default_models(
@@ -257,7 +283,7 @@ def is_secure_key_storage_available() -> bool:
 
 def get_secure_ai_api_key(provider: str) -> str:
     if keyring is None:
-        return os.getenv(get_ai_provider_env_var(provider), "")
+        return os.getenv(_get_key_slot_env_var(provider), "")
     try:
         return keyring.get_password(AI_CREDENTIAL_SERVICE, provider) or ""
     except KeyringError:
@@ -266,14 +292,14 @@ def get_secure_ai_api_key(provider: str) -> str:
 
 def set_secure_ai_api_key(provider: str, api_key: str) -> None:
     if keyring is None:
-        os.environ[get_ai_provider_env_var(provider)] = api_key
+        os.environ[_get_key_slot_env_var(provider)] = api_key
         return
     keyring.set_password(AI_CREDENTIAL_SERVICE, provider, api_key)
 
 
 def delete_secure_ai_api_key(provider: str) -> None:
     if keyring is None:
-        os.environ.pop(get_ai_provider_env_var(provider), None)
+        os.environ.pop(_get_key_slot_env_var(provider), None)
         return
     try:
         keyring.delete_password(AI_CREDENTIAL_SERVICE, provider)
@@ -300,6 +326,133 @@ def fetch_available_models(
         ]
         return [model for model in ids if model]
     return get_provider_default_models(provider, base_url_override=base_url_override)
+
+
+def _get_current_ai_provider() -> str:
+    load_persisted_ai_settings()
+    settings_provider = _load_app_settings().get("ai_provider", "")
+    persisted_provider = settings_provider if isinstance(settings_provider, str) else ""
+    return _normalize_provider_name(
+        persisted_provider.strip() or os.getenv("AI_PROVIDER", "")
+    )
+
+
+def _get_ai_api_key_for_provider(provider: str) -> tuple[str, str, str]:
+    provider = _normalize_provider_name(provider)
+    key_slot = provider
+    env_var = get_ai_provider_env_var(provider)
+    if provider == "openai_compatible":
+        choice = get_openai_compatible_base_url_choice()
+        key_slot = get_openai_compatible_storage_key_name(choice)
+        env_var = get_openai_compatible_env_var(choice)
+
+    api_key = os.getenv(env_var, "").strip() or get_secure_ai_api_key(key_slot).strip()
+    if provider == "openai_compatible" and not api_key:
+        fallback_env_var = get_ai_provider_env_var(provider)
+        api_key = (
+            os.getenv(fallback_env_var, "").strip()
+            or get_secure_ai_api_key(provider).strip()
+        )
+        env_var = fallback_env_var
+    return api_key, key_slot, env_var
+
+
+def _get_ai_base_url(provider: str) -> str:
+    provider = _normalize_provider_name(provider)
+    if provider == "openai_compatible":
+        return get_openai_compatible_base_url().rstrip("/")
+    return AI_PROVIDER_BASE_URLS[provider].rstrip("/")
+
+
+def _extract_openai_compatible_text(response_data: dict[str, Any]) -> str:
+    choices = response_data.get("choices")
+    if not isinstance(choices, list) or not choices:
+        return ""
+    first_choice = choices[0] if isinstance(choices[0], dict) else {}
+    message = first_choice.get("message")
+    if isinstance(message, dict):
+        content = message.get("content")
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            return "".join(
+                item.get("text", "")
+                for item in content
+                if isinstance(item, dict)
+                and item.get("type") in {"text", "output_text"}
+            )
+    text = first_choice.get("text")
+    return text if isinstance(text, str) else ""
+
+
+def _extract_anthropic_text(response_data: dict[str, Any]) -> str:
+    content = response_data.get("content")
+    if not isinstance(content, list):
+        return ""
+    return "".join(
+        item.get("text", "")
+        for item in content
+        if isinstance(item, dict) and item.get("type") == "text"
+    )
+
+
+def _request_translation_from_provider(
+    provider: str,
+    api_key: str,
+    model: str,
+    content: str,
+    source_language: str,
+    target_language: str,
+) -> str:
+    system_prompt = (
+        "Translate Markdown while preserving Markdown structure, front matter, "
+        "links, tables, code fences, inline code, math, and HTML. Return only the "
+        "translated Markdown."
+    )
+    user_prompt = (
+        f"Source language: {source_language or 'auto'}\n"
+        f"Target language: {target_language}\n\n"
+        "Markdown:\n"
+        f"{content}"
+    )
+    base_url = _get_ai_base_url(provider)
+    headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+
+    if provider == "anthropic":
+        headers["anthropic-version"] = "2023-06-01"
+        response = requests.post(
+            f"{base_url}/messages",
+            headers=headers,
+            json={
+                "model": model,
+                "max_tokens": 4096,
+                "system": system_prompt,
+                "messages": [{"role": "user", "content": user_prompt}],
+            },
+            timeout=60,
+        )
+        response.raise_for_status()
+        translated = _extract_anthropic_text(response.json()).strip()
+    else:
+        response = requests.post(
+            f"{base_url}/chat/completions",
+            headers=headers,
+            json={
+                "model": model,
+                "messages": [
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_prompt},
+                ],
+                "temperature": 0.2,
+            },
+            timeout=60,
+        )
+        response.raise_for_status()
+        translated = _extract_openai_compatible_text(response.json()).strip()
+
+    if not translated:
+        raise RuntimeError("AI provider returned an empty translation.")
+    return translated
 
 
 def get_ai_automation_task_templates() -> list[dict[str, Any]]:
@@ -438,6 +591,15 @@ def build_ai_automation_fallback(
     user_message: str, document_text: str = "", selected_text: str = ""
 ) -> dict[str, Any] | None:
     lowered = (user_message or "").lower()
+    slash_command = lowered.strip()
+    if slash_command == "/summarize":
+        lowered = "generate summary"
+    elif slash_command == "/format":
+        lowered = "format this section"
+    elif slash_command == "/toc":
+        lowered = "generate table of contents"
+    elif slash_command == "/fix-code":
+        lowered = "format code blocks and correct syntax"
     selection = selected_text if isinstance(selected_text, str) else ""
     document = document_text if isinstance(document_text, str) else ""
     target = selection if selection.strip() else document
@@ -581,6 +743,23 @@ def request_ai_agent_response(
 def translate_markdown_with_ai(
     content: str, source_language: str, target_language: str
 ) -> str:
-    raise TranslationConfigError(
-        "AI translation requires a configured provider API key."
+    if not (content or "").strip():
+        return ""
+
+    provider = _get_current_ai_provider()
+    api_key, _key_slot, env_var = _get_ai_api_key_for_provider(provider)
+    if not api_key:
+        raise TranslationConfigError(
+            "AI translation requires a configured provider API key.",
+            provider_name=provider,
+            env_var=env_var,
+        )
+
+    return _request_translation_from_provider(
+        provider,
+        api_key,
+        get_ai_provider_model(provider),
+        content,
+        source_language,
+        target_language,
     )

--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -92,8 +92,10 @@ def get_ai_settings():
         }
     settings["providers"] = providers
     settings["provider_order"] = list(logic.AI_PROVIDER_PRIORITY)
+    settings_provider = settings.get("ai_provider", "")
     settings["ai_provider"] = logic._normalize_provider_name(
-        os.getenv("AI_PROVIDER", "") or settings.get("ai_provider", "")
+        (settings_provider if isinstance(settings_provider, str) else "").strip()
+        or os.getenv("AI_PROVIDER", "")
     )
     settings["openai_compatible_base_url_choice"] = (
         logic.get_openai_compatible_base_url_choice()
@@ -265,6 +267,7 @@ def translate(payload: TranslatePayload):
             detail={
                 "message": str(exc),
                 "provider": getattr(exc, "provider_name", None),
+                "env_var": getattr(exc, "env_var", None),
             },
         )
     except Exception as exc:

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -10,15 +10,17 @@
 import { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import type { editor as MonacoEditor } from "monaco-editor";
 import { useEditor } from "@/hooks/useEditor";
+import { useSlashCommands, isSlashTriggerPosition, type SlashCommand } from "@/hooks/useSlashCommands";
 import TabBar from "@/components/TabBar";
 import Toolbar from "@/components/Toolbar";
 import MenuBar, { type MenuGroup } from "@/components/MenuBar";
 import EditorPane from "@/components/EditorPane";
 import PreviewPane from "@/components/PreviewPane";
 import SplitPane from "@/components/SplitPane";
-import AIPanel from "@/components/AIPanel";
+import AIPanel, { type AIPanelTab } from "@/components/AIPanel";
+import SlashCommandMenu from "@/components/SlashCommandMenu";
 import StatusBar from "@/components/StatusBar";
-import { Export, Files, getBaseUrl, type ExportPayload } from "@/lib/api";
+import { AI, Export, Files, getBaseUrl, type ExportPayload } from "@/lib/api";
 import {
   resolveShortcutDefinitions,
   shortcutMatchesEvent,
@@ -79,10 +81,12 @@ export default function HomePage() {
   const editor = useEditor();
   const [showPreview] = useState(true);
   const [showAIPanel, setShowAIPanel] = useState(false);
+  const [aiPanelInitialTab, setAiPanelInitialTab] = useState<AIPanelTab | undefined>(undefined);
   const [split, setSplit] = useState(50);
   const [isLikelyTauriRuntime, setIsLikelyTauriRuntime] = useState(false);
   const [backendStatus, setBackendStatus] = useState<"starting" | "ready" | "error">("ready");
   const [backendMessage, setBackendMessage] = useState<string | null>(null);
+  const [monacoReady, setMonacoReady] = useState(false);
   const monacoRef = useRef<MonacoEditor.IStandaloneCodeEditor | null>(null);
   const dragCounterRef = useRef(0);
   const openFileRef = useRef(editor.openFile);
@@ -474,6 +478,169 @@ export default function HomePage() {
     return mono.getModel()?.getValueInRange(sel) ?? "";
   };
 
+  // ── Slash commands ──────────────────────────────────────────────────────────
+  const slash = useSlashCommands();
+
+  const executeSlashCommand = useCallback(
+    async (command: SlashCommand) => {
+      const mono = monacoRef.current;
+      const model = mono?.getModel();
+      const trigger = slash.triggerPosition;
+      const position = mono?.getPosition();
+      if (mono && model && trigger && position) {
+        mono.executeEdits("slash-command", [
+          {
+            range: {
+              startLineNumber: trigger.lineNumber,
+              startColumn: trigger.column - 1,
+              endLineNumber: position.lineNumber,
+              endColumn: position.column,
+            },
+            text: "",
+          },
+        ]);
+        mono.focus();
+      }
+      slash.close();
+
+      // Read the live buffer post-edit — editor.activeTab.content is React state
+      // and has not yet caught up with the executeEdits call above.
+      const documentText = model?.getValue() ?? editor.activeTab.content;
+
+      if (command.kind === "insert-table") {
+        insertTable();
+        return;
+      }
+      if (command.kind === "open-translate-tab") {
+        setAiPanelInitialTab("translate");
+        setShowAIPanel(true);
+        return;
+      }
+      if (!command.prompt) {
+        alert(`AI command "${command.label}" is not available (automation templates failed to load).`);
+        return;
+      }
+      try {
+        const result = await AI.chat({
+          message: command.prompt,
+          document_text: documentText,
+          selected_text: getSelectedText(),
+          chat_history: [],
+        });
+        if (result.proposed_action.type !== "none") {
+          handleAIApplyAction(result.proposed_action.type, result.proposed_action.content);
+        } else if (result.assistant_message) {
+          alert(result.assistant_message);
+        }
+      } catch (err) {
+        alert(`AI command failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    },
+    [slash, insertTable, editor, handleAIApplyAction]
+  );
+
+  const slashRef = useRef({
+    isOpen: slash.isOpen,
+    triggerPosition: slash.triggerPosition,
+    moveSelection: slash.moveSelection,
+    close: slash.close,
+    openAt: slash.openAt,
+    getSelectedCommand: slash.getSelectedCommand,
+    execute: executeSlashCommand,
+  });
+  useEffect(() => {
+    slashRef.current = {
+      isOpen: slash.isOpen,
+      triggerPosition: slash.triggerPosition,
+      moveSelection: slash.moveSelection,
+      close: slash.close,
+      openAt: slash.openAt,
+      getSelectedCommand: slash.getSelectedCommand,
+      execute: executeSlashCommand,
+    };
+  });
+
+  useEffect(() => {
+    const mono = monacoRef.current;
+    if (!mono || !monacoReady) return;
+
+    const handleSync = () => {
+      const model = mono.getModel();
+      const position = mono.getPosition();
+      if (!model || !position) return;
+      const s = slashRef.current;
+
+      if (!s.isOpen) {
+        if (isSlashTriggerPosition(model, position)) {
+          s.openAt(position);
+        }
+        return;
+      }
+
+      const trigger = s.triggerPosition;
+      if (!trigger || position.lineNumber !== trigger.lineNumber || position.column < trigger.column) {
+        s.close();
+        return;
+      }
+      const lineContent = model.getLineContent(trigger.lineNumber);
+      if (lineContent.charAt(trigger.column - 2) !== "/") {
+        s.close();
+        return;
+      }
+      const queryText = model.getValueInRange({
+        startLineNumber: trigger.lineNumber,
+        startColumn: trigger.column,
+        endLineNumber: position.lineNumber,
+        endColumn: position.column,
+      });
+      if (/\s/.test(queryText)) {
+        s.close();
+        return;
+      }
+      slash.updateQuery(queryText);
+    };
+
+    const d1 = mono.onDidChangeModelContent(handleSync);
+    const d2 = mono.onDidChangeCursorPosition(handleSync);
+    const d3 = mono.onKeyDown((event) => {
+      const s = slashRef.current;
+      if (!s.isOpen) return;
+      const key = event.browserEvent.key;
+      if (key === "ArrowDown") {
+        event.preventDefault();
+        event.stopPropagation();
+        s.moveSelection(1);
+      } else if (key === "ArrowUp") {
+        event.preventDefault();
+        event.stopPropagation();
+        s.moveSelection(-1);
+      } else if (key === "Enter") {
+        const cmd = s.getSelectedCommand();
+        if (cmd) {
+          event.preventDefault();
+          event.stopPropagation();
+          void s.execute(cmd);
+        }
+      } else if (key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
+        s.close();
+      }
+    });
+
+    return () => {
+      d1.dispose();
+      d2.dispose();
+      d3.dispose();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [monacoReady]);
+
+  const slashMenuPosition =
+    slash.isOpen && slash.triggerPosition && monacoRef.current
+      ? monacoRef.current.getScrolledVisiblePosition(slash.triggerPosition)
+      : null;
+
   useEffect(() => {
     openFileRef.current = editor.openFile;
     openTextAsTabRef.current = editor.openTextAsTab;
@@ -684,13 +851,25 @@ export default function HomePage() {
           split={split}
           onSplitChange={setSplit}
           left={
-            <EditorPane
-              value={editor.activeTab.content}
-              onChange={editor.handleContentChange}
-              darkMode={editor.darkMode}
-              fontSize={editor.fontSize}
-              onMount={(e) => { monacoRef.current = e; }}
-            />
+            <div className="relative h-full">
+              <EditorPane
+                value={editor.activeTab.content}
+                onChange={editor.handleContentChange}
+                darkMode={editor.darkMode}
+                fontSize={editor.fontSize}
+                onMount={(e) => { monacoRef.current = e; setMonacoReady(true); }}
+              />
+              {slash.isOpen && slashMenuPosition && (
+                <SlashCommandMenu
+                  commands={slash.filteredCommands}
+                  selectedIndex={slash.selectedIndex}
+                  top={slashMenuPosition.top + slashMenuPosition.height}
+                  left={slashMenuPosition.left}
+                  onSelect={(cmd) => { void executeSlashCommand(cmd); }}
+                  onClose={slash.close}
+                />
+              )}
+            </div>
           }
           right={
             showPreview ? (
@@ -709,6 +888,7 @@ export default function HomePage() {
             documentText={editor.activeTab.content}
             selectedText={getSelectedText()}
             onApplyAction={handleAIApplyAction}
+            initialTab={aiPanelInitialTab}
           />
         )}
       </div>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -87,6 +87,7 @@ export default function HomePage() {
   const [backendStatus, setBackendStatus] = useState<"starting" | "ready" | "error">("ready");
   const [backendMessage, setBackendMessage] = useState<string | null>(null);
   const [monacoReady, setMonacoReady] = useState(false);
+  const [selectedText, setSelectedText] = useState("");
   const monacoRef = useRef<MonacoEditor.IStandaloneCodeEditor | null>(null);
   const dragCounterRef = useRef(0);
   const openFileRef = useRef(editor.openFile);
@@ -470,13 +471,17 @@ export default function HomePage() {
     [editor]
   );
 
-  const getSelectedText = () => {
+  const getSelectedText = useCallback(() => {
     const mono = monacoRef.current;
     if (!mono) return "";
     const sel = mono.getSelection();
     if (!sel) return "";
     return mono.getModel()?.getValueInRange(sel) ?? "";
-  };
+  }, []);
+
+  const syncSelectedText = useCallback(() => {
+    setSelectedText(getSelectedText());
+  }, [getSelectedText]);
 
   // ── Slash commands ──────────────────────────────────────────────────────────
   const slash = useSlashCommands();
@@ -536,7 +541,7 @@ export default function HomePage() {
         alert(`AI command failed: ${err instanceof Error ? err.message : String(err)}`);
       }
     },
-    [slash, insertTable, editor, handleAIApplyAction]
+    [slash, insertTable, editor, handleAIApplyAction, getSelectedText]
   );
 
   const slashRef = useRef({
@@ -565,6 +570,7 @@ export default function HomePage() {
     if (!mono || !monacoReady) return;
 
     const handleSync = () => {
+      syncSelectedText();
       const model = mono.getModel();
       const position = mono.getPosition();
       if (!model || !position) return;
@@ -602,7 +608,8 @@ export default function HomePage() {
 
     const d1 = mono.onDidChangeModelContent(handleSync);
     const d2 = mono.onDidChangeCursorPosition(handleSync);
-    const d3 = mono.onKeyDown((event) => {
+    const d3 = mono.onDidChangeCursorSelection(syncSelectedText);
+    const d4 = mono.onKeyDown((event) => {
       const s = slashRef.current;
       if (!s.isOpen) return;
       const key = event.browserEvent.key;
@@ -632,9 +639,10 @@ export default function HomePage() {
       d1.dispose();
       d2.dispose();
       d3.dispose();
+      d4.dispose();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [monacoReady]);
+  }, [monacoReady, syncSelectedText]);
 
   const slashMenuPosition =
     slash.isOpen && slash.triggerPosition && monacoRef.current
@@ -886,7 +894,7 @@ export default function HomePage() {
         {showAIPanel && (
           <AIPanel
             documentText={editor.activeTab.content}
-            selectedText={getSelectedText()}
+            selectedText={selectedText}
             onApplyAction={handleAIApplyAction}
             initialTab={aiPanelInitialTab}
           />

--- a/frontend/src/components/AIPanel.tsx
+++ b/frontend/src/components/AIPanel.tsx
@@ -21,6 +21,16 @@ const LANGUAGES = [
   "Italian", "Dutch", "Polish", "Turkish",
 ];
 
+const INSERT_TABLE_MARKDOWN =
+  "| Column 1 | Column 2 | Column 3 |\n| --- | --- | --- |\n| Cell | Cell | Cell |";
+
+const CHAT_SLASH_PROMPTS: Record<string, string> = {
+  "/summarize": "generate summary",
+  "/format": "format this section",
+  "/toc": "generate table of contents",
+  "/fix-code": "format code blocks and correct syntax",
+};
+
 export default function AIPanel({
   documentText,
   selectedText = "",
@@ -172,6 +182,20 @@ export default function AIPanel({
     const msg = input.trim();
     if (!msg || loading) return;
     setInput("");
+    const slashCommand = msg.toLowerCase();
+    if (slashCommand === "/translate") {
+      setTab("translate");
+      return;
+    }
+    if (slashCommand === "/insert-table") {
+      onApplyAction?.("replace_selection", INSERT_TABLE_MARKDOWN);
+      return;
+    }
+    const slashPrompt = CHAT_SLASH_PROMPTS[slashCommand];
+    if (slashPrompt) {
+      await sendMessage(slashPrompt, documentText, selectedText);
+      return;
+    }
     await sendMessage(msg, documentText, selectedText);
   };
 
@@ -238,7 +262,7 @@ export default function AIPanel({
           <div className="flex-1 overflow-y-auto p-3 space-y-3">
             {messages.length === 0 && (
               <p className="text-gray-400 dark:text-gray-500 text-xs">
-                Ask me to summarize, generate a TOC, translate, fix code blocks, or anything else…
+                Try /summarize, /translate, /format, /toc, /fix-code, or /insert-table.
               </p>
             )}
             {messages.map((msg) => (

--- a/frontend/src/components/AIPanel.tsx
+++ b/frontend/src/components/AIPanel.tsx
@@ -4,10 +4,15 @@ import { useState, useRef, useEffect } from "react";
 import { useAIChat } from "@/hooks/useAIChat";
 import { AI, type AISettings } from "@/lib/api";
 
+export type AIPanelTab = "chat" | "translate" | "settings";
+type Tab = AIPanelTab;
+
 type Props = {
   documentText: string;
   selectedText?: string;
   onApplyAction?: (type: string, content: string) => void;
+  /** Force the panel to switch to this tab (e.g. deep-linking from a slash command) */
+  initialTab?: Tab;
 };
 
 const LANGUAGES = [
@@ -16,15 +21,19 @@ const LANGUAGES = [
   "Italian", "Dutch", "Polish", "Turkish",
 ];
 
-type Tab = "chat" | "translate" | "settings";
-
 export default function AIPanel({
   documentText,
   selectedText = "",
   onApplyAction,
+  initialTab,
 }: Props) {
   const { messages, loading, error, sendMessage, translate, clearHistory } = useAIChat();
-  const [tab, setTab] = useState<Tab>("chat");
+  const [tab, setTab] = useState<Tab>(initialTab ?? "chat");
+
+  useEffect(() => {
+    if (initialTab) setTab(initialTab);
+  }, [initialTab]);
+
   const [input, setInput] = useState("");
   const [sourceLang, setSourceLang] = useState("Auto Detect");
   const [targetLang, setTargetLang] = useState("English");

--- a/frontend/src/components/EditorPane.tsx
+++ b/frontend/src/components/EditorPane.tsx
@@ -8,6 +8,7 @@
 
 import dynamic from "next/dynamic";
 import type { editor } from "monaco-editor";
+import type Monaco from "monaco-editor";
 
 // Monaco must be loaded client-side only (no SSR)
 const MonacoEditor = dynamic(
@@ -20,8 +21,8 @@ type Props = {
   onChange: (value: string | undefined) => void;
   darkMode: boolean;
   fontSize: number;
-  /** Called with the monaco editor instance after mount */
-  onMount?: (editor: editor.IStandaloneCodeEditor) => void;
+  /** Called with the monaco editor instance and the monaco namespace after mount */
+  onMount?: (editor: editor.IStandaloneCodeEditor, monaco: typeof Monaco) => void;
 };
 
 export default function EditorPane({ value, onChange, darkMode, fontSize, onMount }: Props) {

--- a/frontend/src/components/SlashCommandMenu.tsx
+++ b/frontend/src/components/SlashCommandMenu.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+/**
+ * SlashCommandMenu.tsx
+ * =====================
+ * Notion-style inline popover listing slash commands, positioned at the
+ * Monaco text cursor. Pure presentation — selection/keyboard logic lives
+ * in useSlashCommands.
+ */
+
+import type { SlashCommand } from "@/hooks/useSlashCommands";
+
+type Props = {
+  commands: SlashCommand[];
+  selectedIndex: number;
+  top: number;
+  left: number;
+  onSelect: (command: SlashCommand) => void;
+  onClose: () => void;
+};
+
+export default function SlashCommandMenu({ commands, selectedIndex, top, left, onSelect, onClose }: Props) {
+  if (commands.length === 0) {
+    return (
+      <div
+        className="absolute z-50 bg-white dark:bg-[#252526] border border-gray-200 dark:border-gray-700 rounded shadow-lg w-64 p-3 text-xs text-gray-400"
+        style={{ top, left }}
+        onMouseLeave={onClose}
+      >
+        No matching commands
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="absolute z-50 bg-white dark:bg-[#252526] border border-gray-200 dark:border-gray-700 rounded shadow-lg w-64 py-1"
+      style={{ top, left }}
+      onMouseLeave={onClose}
+    >
+      {commands.map((command, index) => (
+        <button
+          key={command.id}
+          onClick={() => onSelect(command)}
+          className={`w-full text-left px-3 py-1.5 text-xs flex flex-col gap-0.5 ${
+            index === selectedIndex
+              ? "bg-blue-500 text-white"
+              : "text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-[#2d2d2d]"
+          }`}
+        >
+          <span className="font-medium">{command.label}</span>
+          <span className={index === selectedIndex ? "text-blue-100" : "text-gray-400 dark:text-gray-500"}>
+            {command.description}
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useSlashCommands.ts
+++ b/frontend/src/hooks/useSlashCommands.ts
@@ -1,0 +1,134 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { editor, IPosition } from "monaco-editor";
+import { AI, type AIAutomationTemplate } from "@/lib/api";
+
+export type SlashCommandId =
+  | "summarize"
+  | "translate"
+  | "format"
+  | "toc"
+  | "fix-code"
+  | "insert-table";
+
+export type SlashCommand = {
+  id: SlashCommandId;
+  label: string;
+  description: string;
+  kind: "ai" | "open-translate-tab" | "insert-table";
+  prompt?: string;
+};
+
+const STATIC_COMMANDS: Omit<SlashCommand, "prompt">[] = [
+  { id: "summarize", label: "/summarize", description: "Summarize the document with AI", kind: "ai" },
+  { id: "translate", label: "/translate", description: "Open the Translate tab", kind: "open-translate-tab" },
+  { id: "format", label: "/format", description: "Apply Markdown formatting with AI", kind: "ai" },
+  { id: "toc", label: "/toc", description: "Generate a table of contents with AI", kind: "ai" },
+  { id: "fix-code", label: "/fix-code", description: "Fix code block fences with AI", kind: "ai" },
+  { id: "insert-table", label: "/insert-table", description: "Insert a Markdown table", kind: "insert-table" },
+];
+
+const TEMPLATE_ID_BY_COMMAND: Record<string, string> = {
+  summarize: "generate_summary",
+  format: "format_selection",
+  toc: "generate_toc",
+  "fix-code": "fix_code_blocks",
+};
+
+export function useSlashCommands() {
+  const [templates, setTemplates] = useState<AIAutomationTemplate[]>([]);
+  const [isOpen, setIsOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [triggerPosition, setTriggerPosition] = useState<IPosition | null>(null);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    AI.getAutomationTemplates()
+      .then((res) => {
+        if (!cancelled) setTemplates(res.templates);
+      })
+      .catch(() => {
+        // AI panel already surfaces backend errors; slash commands degrade to no AI prompts.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const commands = useMemo<SlashCommand[]>(
+    () =>
+      STATIC_COMMANDS.map((cmd) => {
+        const templateId = TEMPLATE_ID_BY_COMMAND[cmd.id];
+        const prompt = templateId ? templates.find((t) => t.id === templateId)?.prompt : undefined;
+        return { ...cmd, prompt };
+      }),
+    [templates]
+  );
+
+  const filteredCommands = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return commands;
+    return commands.filter((c) => c.id.includes(q) || c.label.toLowerCase().includes(q));
+  }, [commands, query]);
+
+  const openAt = useCallback((position: IPosition) => {
+    setTriggerPosition(position);
+    setQuery("");
+    setSelectedIndex(0);
+    setIsOpen(true);
+  }, []);
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+    setTriggerPosition(null);
+    setQuery("");
+    setSelectedIndex(0);
+  }, []);
+
+  const updateQuery = useCallback((text: string) => {
+    setQuery(text);
+    setSelectedIndex(0);
+  }, []);
+
+  const moveSelection = useCallback(
+    (delta: number) => {
+      setSelectedIndex((prev) => {
+        const count = filteredCommands.length;
+        if (count === 0) return 0;
+        return (prev + delta + count) % count;
+      });
+    },
+    [filteredCommands.length]
+  );
+
+  const getSelectedCommand = useCallback(() => {
+    return filteredCommands[selectedIndex] ?? null;
+  }, [filteredCommands, selectedIndex]);
+
+  return {
+    isOpen,
+    query,
+    filteredCommands,
+    triggerPosition,
+    selectedIndex,
+    openAt,
+    close,
+    updateQuery,
+    moveSelection,
+    getSelectedCommand,
+  };
+}
+
+/**
+ * True only when a "/" at `position` starts a fresh trigger: line-start
+ * or preceded by whitespace, never mid-word (e.g. inside "foo/bar").
+ */
+export function isSlashTriggerPosition(model: editor.ITextModel, position: IPosition): boolean {
+  const lineContent = model.getLineContent(position.lineNumber);
+  const beforeCursor = lineContent.slice(0, position.column - 1);
+  if (!beforeCursor.endsWith("/")) return false;
+  const charBeforeSlash = beforeCursor.slice(-2, -1);
+  return charBeforeSlash === "" || /\s/.test(charBeforeSlash);
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -214,11 +214,24 @@ export type AgentChatPayload = {
 export type AgentResponse = {
   assistant_message: string;
   proposed_action: {
-    type: "replace_document" | "replace_selection" | "none";
+    type:
+      | "replace_document"
+      | "replace_selection"
+      | "insert_below_document"
+      | "insert_below_selection"
+      | "insert_below"
+      | "none";
     content: string;
     reason: string;
   };
   used_provider: string;
+};
+
+export type AIAutomationTemplate = {
+  id: string;
+  title: string;
+  prompt: string;
+  requires_selection: boolean;
 };
 
 export type AIProviderInfo = {
@@ -395,7 +408,7 @@ export const AI = {
     }),
 
   getAutomationTemplates: () =>
-    apiFetch<{ templates: unknown[] }>("/api/ai/automation/templates"),
+    apiFetch<{ templates: AIAutomationTemplate[] }>("/api/ai/automation/templates"),
 
   getAutomationLogs: (limit = 100) =>
     apiFetch<{ logs: unknown[] }>(`/api/ai/automation/logs?limit=${limit}`),

--- a/tests/test_ai_automation_logic.py
+++ b/tests/test_ai_automation_logic.py
@@ -111,6 +111,39 @@ class TestAIAutomationLogic(unittest.TestCase):
         self.assertEqual(result["proposed_action"]["reason"], "no_content_for_summary")
         self.assertIn("No document content", result["assistant_message"])
 
+    def test_slash_summary_command_uses_summary_fallback(self):
+        result = build_ai_automation_fallback(
+            "/summarize",
+            document_text="# Title\n\nThis is a test document.",
+            selected_text="",
+        )
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["proposed_action"]["type"], "replace_document")
+        self.assertIn("## Summary", result["assistant_message"])
+
+    def test_slash_toc_command_uses_toc_fallback(self):
+        result = build_ai_automation_fallback(
+            "/toc",
+            document_text="# Title\n\n## Section",
+            selected_text="",
+        )
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["proposed_action"]["type"], "replace_document")
+        self.assertIn("## Table of Contents", result["proposed_action"]["content"])
+
+    def test_slash_fix_code_command_uses_code_fallback(self):
+        result = build_ai_automation_fallback(
+            "/fix-code",
+            document_text="",
+            selected_text="```\nprint('hello')\n",
+        )
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["proposed_action"]["type"], "replace_selection")
+        self.assertTrue(result["proposed_action"]["content"].strip().endswith("```"))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_ai_provider_config_logic.py
+++ b/tests/test_ai_provider_config_logic.py
@@ -90,6 +90,91 @@ class TestAIProviderConfigLogic(unittest.TestCase):
         self.assertTrue(len(navidia_defaults) > 0)
         self.assertIn("llama-3.3-70b-versatile", groq_defaults)
 
+    def test_openai_compatible_slot_uses_choice_specific_env_without_keyring(self):
+        with (
+            patch.object(logic, "keyring", None),
+            patch.dict(
+                os.environ,
+                {
+                    "OPENAI_COMPATIBLE_BASE_URL_CHOICE": "groq",
+                    "OPENAI_COMPATIBLE_GROQ_API_KEY": "groq-key",
+                    "OPENAI_COMPATIBLE_API_KEY": "",
+                },
+                clear=False,
+            ),
+        ):
+            api_key, key_slot, env_var = logic._get_ai_api_key_for_provider(
+                "openai_compatible"
+            )
+
+        self.assertEqual(api_key, "groq-key")
+        self.assertEqual(key_slot, "openai_compatible_groq")
+        self.assertEqual(env_var, "OPENAI_COMPATIBLE_GROQ_API_KEY")
+
+    def test_provider_and_model_are_persisted_to_settings(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            settings_file = Path(tmp_dir) / "settings.json"
+            with (
+                patch.object(logic, "APP_SETTINGS_FILE_PATH", settings_file),
+                patch.dict(os.environ, {"AI_PROVIDER": "", "OPENAI_MODEL": ""}),
+            ):
+                logic.set_current_ai_provider("openai")
+                logic.set_ai_provider_model("openai", "gpt-test")
+
+                self.assertEqual(logic._get_current_ai_provider(), "openai")
+                self.assertEqual(logic.get_ai_provider_model("openai"), "gpt-test")
+
+    def test_persisted_provider_takes_precedence_over_stale_env_provider(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            settings_file = Path(tmp_dir) / "settings.json"
+            with (
+                patch.object(logic, "APP_SETTINGS_FILE_PATH", settings_file),
+                patch.dict(os.environ, {"AI_PROVIDER": "openrouter"}, clear=False),
+            ):
+                logic._save_app_settings({"ai_provider": "openai"})
+
+                self.assertEqual(logic._get_current_ai_provider(), "openai")
+
+    def test_translate_uses_configured_openai_compatible_provider(self):
+        class _DummyResp:
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return {
+                    "choices": [{"message": {"content": "# Titel\n\nHallo **Welt**."}}]
+                }
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            settings_file = Path(tmp_dir) / "settings.json"
+            with (
+                patch.object(logic, "APP_SETTINGS_FILE_PATH", settings_file),
+                patch.object(logic, "keyring", None),
+                patch.dict(
+                    os.environ,
+                    {
+                        "AI_PROVIDER": "openai_compatible",
+                        "OPENAI_COMPATIBLE_BASE_URL_CHOICE": "groq",
+                        "OPENAI_COMPATIBLE_GROQ_API_KEY": "groq-key",
+                        "OPENAI_COMPATIBLE_MODEL": "llama-test",
+                    },
+                ),
+                patch(
+                    "backend.ai_logic.requests.post", return_value=_DummyResp()
+                ) as mock_post,
+            ):
+                translated = logic.translate_markdown_with_ai(
+                    "# Title\n\nHello **world**.", "English", "German"
+                )
+
+        called_url = mock_post.call_args[0][0]
+        called_json = mock_post.call_args.kwargs["json"]
+        called_headers = mock_post.call_args.kwargs["headers"]
+        self.assertEqual(called_url, "https://api.groq.com/openai/v1/chat/completions")
+        self.assertEqual(called_json["model"], "llama-test")
+        self.assertEqual(called_headers["Authorization"], "Bearer groq-key")
+        self.assertEqual(translated, "# Titel\n\nHallo **Welt**.")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes: #221 

## Changes

- Added `useSlashCommands()` (`frontend/src/hooks/useSlashCommands.ts`) — trigger detection (fires only at line-start or after whitespace, never mid-word), the static command list (`/summarize`, `/translate`, `/format`, `/toc`, `/fix-code`, `/insert-table`), live-loaded AI prompt text from `AI.getAutomationTemplates()`, and filtering/keyboard-navigation state.
- Added `SlashCommandMenu.tsx` — a Notion-style inline popover styled after `RecentFilesMenu.tsx`, positioned at the Monaco cursor via `getScrolledVisiblePosition`, listing filtered commands with keyboard-selection highlighting.
- Wired the hook and menu into `frontend/src/app/page.tsx`: Monaco `onDidChangeModelContent`/`onDidChangeCursorPosition`/`onKeyDown` listeners detect the `/` trigger, track the typed query, and intercept Arrow/Enter/Escape only while the menu is open. `executeSlashCommand()` strips the typed `/command` text from the buffer, then either runs the action locally (`/insert-table`), deep-links into the AI panel (`/translate`), or calls `/api/ai/chat` with the matching automation-template prompt and applies the result via the existing `handleAIApplyAction`.
- Widened `EditorPane`'s `onMount` prop to also forward the `monaco` namespace (needed for range/position APIs), and added an `initialTab` prop to `AIPanel` so `/translate` can open it directly on the Translate tab.
- Typed `AI.getAutomationTemplates()`'s return value (`AIAutomationTemplate[]`, was `unknown[]`) and widened `AgentResponse.proposed_action.type` to include the `insert_below_*` variants already handled by `handleAIApplyAction`, in `frontend/src/lib/api.ts`.
- Documented the six commands in a new "Slash Commands" section in `README.MD`.

## Notes

Fixed during testing: AI commands were sending stale `editor.activeTab.content` (React state not yet caught up with the just-applied edit removing the typed `/command` text) as `document_text` to the backend, so results retained the leftover trigger text (e.g. a trailing `/toc`). Fixed by reading the live Monaco buffer (`model.getValue()`) immediately after the edit instead of the React-state closure.