### PR TITLE
Feat: Open external links in a new tab in generated HTML (#226)

### DIFF
--- a/backend/renderer.py
+++ b/backend/renderer.py
@@ -281,6 +281,13 @@ def render_markdown(
   </style>
   <script>
     document.addEventListener('DOMContentLoaded', function() {{
+      document.querySelectorAll('a').forEach(function(link) {{
+        if (link.href.startsWith('http://') || link.href.startsWith('https://')) {{
+          link.setAttribute('target', '_blank');
+          link.setAttribute('rel', 'noopener noreferrer');
+        }}
+      }});
+      
       document.querySelectorAll('pre code').forEach(function(block) {{
         var btn = document.createElement('button');
         btn.className = 'copy-button';


### PR DESCRIPTION
Resolves #226. Injected a lightweight script into the generated HTML output to dynamically add target='_blank' to all external HTTP/HTTPS links, ensuring they open in a new tab while safely preserving internal anchor links.