### PR TITLE
fix: keyboard shortcuts in packaged app

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -419,6 +419,11 @@ export default function HomePage() {
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
+      // Tauri's packaged WebView and Monaco can handle bubbling key events
+      // before they reach this listener. Capture the event so app shortcuts
+      // remain available regardless of which editor element has focus.
+      // Never intercept keys while an IME composition is in progress.
+      if (event.isComposing) return;
       const editableTarget = isEditableTarget(event.target);
       const isMonacoTarget =
         event.target instanceof HTMLElement && Boolean(event.target.closest(".monaco-editor"));
@@ -434,8 +439,8 @@ export default function HomePage() {
       }
     };
 
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => window.removeEventListener("keydown", onKeyDown, true);
   }, [actions, shortcuts]);
 
   const handleAIApplyAction = useCallback(


### PR DESCRIPTION
## Summary

Fixes keyboard shortcuts becoming unreliable in the packaged Tauri desktop app.

## Changes

- Register the global keyboard shortcut handler during the capture phase.
- Prevent Monaco and WebView handlers from swallowing application shortcuts.
- Ignore shortcuts while IME composition is active.
- Preserve existing shortcut behavior in development mode.

## Testing

- `git diff --check` passes.
- Frontend build could not be run because dependencies are not installed.


closes #214