### PR TITLE
Add local packaging scripts for Linux, macOS, and Windows

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -29,6 +29,8 @@ Thank you to all the contributors who have helped make Markdown Reader better!
 - [@korbonits](https://github.com/korbonits) - chore: migrate to uv, ruff, and ty (#158)
 - [@Yolsh](https://github.com/Yolsh) - moved the installation instructions round so that it made more sense … (#164)
 - [@dhuhaaf](https://github.com/dhuhaaf) - new features: add word count status bar and recent files menu (#165)
+- [@Dhruv-Sharma29](https://github.com/Dhruv-Sharma29) - Local packaging scripts and release workflow improvements
+
 ## How to Contribute
 
 We welcome contributions! Please see our [CONTRIBUTING.md](CONTRIBUTING.md) guide for details on how to:

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -29,7 +29,7 @@ Thank you to all the contributors who have helped make Markdown Reader better!
 - [@korbonits](https://github.com/korbonits) - chore: migrate to uv, ruff, and ty (#158)
 - [@Yolsh](https://github.com/Yolsh) - moved the installation instructions round so that it made more sense … (#164)
 - [@dhuhaaf](https://github.com/dhuhaaf) - new features: add word count status bar and recent files menu (#165)
-- [@Dhruv-Sharma29](https://github.com/Dhruv-Sharma29) - Local packaging scripts and release workflow improvements
+- [@Dhruv-Sharma29](https://github.com/Dhruv-Sharma29) - Keyboard shortcuts and local packaging improvements (#232,#237)
 
 ## How to Contribute
 

--- a/README.MD
+++ b/README.MD
@@ -86,6 +86,23 @@ complete, but WeasyPrint generally provides better layout fidelity.
 
 > **Note for Contributors:** After cloning, run `uv sync --extra dev` and `uv run pre-commit install` to set up linting hooks.
 
+### Build release artifacts locally
+
+To package the desktop app without using GitHub Actions, run the platform-specific helper from the project root:
+
+```bash
+# Linux
+./scripts/package-linux.sh
+
+# macOS
+./scripts/package-macos.sh
+
+# Windows (PowerShell)
+./scripts/package-windows.ps1
+```
+
+Each script stages the Python backend sidecar, installs the frontend dependencies, runs the matching Tauri release build, and copies the final bundle(s) into `release-artifacts/` for easy distribution. Pass `--help` to see the default target and override options.
+
 ---
 
 ## 📦 Desktop Downloads

--- a/scripts/package-common.sh
+++ b/scripts/package-common.sh
@@ -126,24 +126,29 @@ run_tauri_build() {
 }
 
 collect_release_artifacts() {
+  local target="$1"
   mkdir -p "${ARTIFACT_DIR}"
-  local bundle_dir="${FRONTEND_DIR}/src-tauri/target/release/bundle"
+  local target_bundle_dir="${FRONTEND_DIR}/src-tauri/target/${target}/release/bundle"
+  local native_bundle_dir="${FRONTEND_DIR}/src-tauri/target/release/bundle"
+  local bundle_dir=""
 
-  if [[ -d "${bundle_dir}" ]]; then
-    info "Collecting packaged artifacts into ${ARTIFACT_DIR}..."
-    cp -a "${bundle_dir}"/. "${ARTIFACT_DIR}/"
-  else
-    warn "No Tauri bundle directory was found under ${bundle_dir}."
-    warn "The build may have failed before producing artifacts."
+  # Tauri places explicitly targeted builds below target/<triple>. Keep the
+  # native path as a fallback for older Tauri versions and native builds.
+  for candidate in "${target_bundle_dir}" "${native_bundle_dir}"; do
+    if [[ -d "${candidate}" ]] &&
+       [[ -n "$(find "${candidate}" -mindepth 1 -maxdepth 1 -print -quit)" ]]; then
+      bundle_dir="${candidate}"
+      break
+    fi
+  done
+
+  if [[ -z "${bundle_dir}" ]]; then
+    die "No packaged artifacts found for target ${target}; checked ${target_bundle_dir} and ${native_bundle_dir}."
   fi
 
-  # `find` exits successfully even when the directory is empty, so inspect
-  # whether it actually returned an entry before claiming success.
-  if [[ -n "$(find "${ARTIFACT_DIR}" -mindepth 1 -maxdepth 1 -print -quit)" ]]; then
-    info "Done. Bundles are ready in ${ARTIFACT_DIR}"
-  else
-    warn "The release-artifacts directory is empty; check the build logs above for errors."
-  fi
+  info "Collecting packaged artifacts from ${bundle_dir} into ${ARTIFACT_DIR}..."
+  cp -a "${bundle_dir}"/. "${ARTIFACT_DIR}/"
+  info "Done. Bundles are ready in ${ARTIFACT_DIR}"
 }
 
 check_run_on_supported_platform() {

--- a/scripts/package-common.sh
+++ b/scripts/package-common.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# Shared logic for local desktop packaging builds.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FRONTEND_DIR="${ROOT}/frontend"
+ARTIFACT_DIR="${ROOT}/release-artifacts"
+
+info() {
+  echo "==> $*"
+}
+
+warn() {
+  echo "WARNING: $*" >&2
+}
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+require_command() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    die "Required command '$cmd' was not found. Install it and retry."
+  fi
+}
+
+ensure_rust_target() {
+  local target="$1"
+
+  if ! command -v rustup >/dev/null 2>&1; then
+    die "Rust is required for packaging. Install rustup from https://rustup.rs and retry."
+  fi
+
+  if ! rustup target list --installed | grep -Fxq "$target"; then
+    info "Installing Rust target ${target}..."
+    rustup target add "$target"
+  fi
+}
+
+ensure_uv() {
+  if ! command -v uv >/dev/null 2>&1; then
+    die "uv is required for packaging. Install it from https://docs.astral.sh/uv/ and retry."
+  fi
+}
+
+ensure_node() {
+  if ! command -v node >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1; then
+    die "Node.js and npm are required for packaging. Install Node 20+ and retry."
+  fi
+}
+
+prepare_linux_system_deps() {
+  if [[ "$(uname -s)" != "Linux" ]]; then
+    return 0
+  fi
+
+  if command -v apt-get >/dev/null 2>&1; then
+    info "Ensuring Linux packaging dependencies are installed..."
+    local apt_cmd=(apt-get update)
+    if command -v sudo >/dev/null 2>&1; then
+      apt_cmd=(sudo apt-get update)
+    fi
+    "${apt_cmd[@]}"
+
+    local install_cmd=(apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf build-essential curl wget file libssl-dev libgtk-3-dev libxdo-dev libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf-2.0-0 libcairo2 libffi-dev)
+    if command -v sudo >/dev/null 2>&1; then
+      install_cmd=(sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf build-essential curl wget file libssl-dev libgtk-3-dev libxdo-dev libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf-2.0-0 libcairo2 libffi-dev)
+    fi
+    "${install_cmd[@]}"
+  fi
+}
+
+build_backend_sidecar() {
+  local target="$1"
+  local bin_ext="${2:-}"
+
+  ensure_uv
+  info "Syncing Python dependencies with uv..."
+  cd "${ROOT}"
+  uv sync --frozen
+
+  info "Building backend sidecar with PyInstaller..."
+  uv run pyinstaller markdown-reader-backend.spec
+
+  mkdir -p "${FRONTEND_DIR}/src-tauri/binaries"
+
+  local src="${ROOT}/dist/markdown-reader-backend${bin_ext}"
+  local dest="${FRONTEND_DIR}/src-tauri/binaries/markdown-reader-backend-${target}${bin_ext}"
+  if [[ ! -f "${src}" ]]; then
+    die "Backend build output not found at ${src}. The PyInstaller step failed."
+  fi
+
+  cp "${src}" "${dest}"
+  chmod +x "${dest}" || true
+
+  local default_dest="${FRONTEND_DIR}/src-tauri/binaries/markdown-reader-backend${bin_ext}"
+  cp "${src}" "${default_dest}"
+  chmod +x "${default_dest}" || true
+
+  info "Backend sidecar staged at ${default_dest}"
+}
+
+install_frontend_dependencies() {
+  ensure_node
+  info "Installing frontend dependencies with npm ci..."
+  cd "${FRONTEND_DIR}"
+  npm ci
+}
+
+run_tauri_build() {
+  local target="$1"
+  shift
+
+  ensure_node
+  if ! command -v cargo >/dev/null 2>&1; then
+    die "Cargo is required to build Tauri. Install the Rust toolchain and retry."
+  fi
+
+  info "Building Tauri desktop bundle for target ${target}..."
+  cd "${FRONTEND_DIR}"
+  export NEXT_EXPORT=1
+  npx tauri build --target "$target" "$@"
+}
+
+collect_release_artifacts() {
+  mkdir -p "${ARTIFACT_DIR}"
+  local bundle_dir="${FRONTEND_DIR}/src-tauri/target/release/bundle"
+
+  if [[ -d "${bundle_dir}" ]]; then
+    info "Collecting packaged artifacts into ${ARTIFACT_DIR}..."
+    cp -a "${bundle_dir}"/. "${ARTIFACT_DIR}/"
+  else
+    warn "No Tauri bundle directory was found under ${bundle_dir}."
+    warn "The build may have failed before producing artifacts."
+  fi
+
+  # `find` exits successfully even when the directory is empty, so inspect
+  # whether it actually returned an entry before claiming success.
+  if [[ -n "$(find "${ARTIFACT_DIR}" -mindepth 1 -maxdepth 1 -print -quit)" ]]; then
+    info "Done. Bundles are ready in ${ARTIFACT_DIR}"
+  else
+    warn "The release-artifacts directory is empty; check the build logs above for errors."
+  fi
+}
+
+check_run_on_supported_platform() {
+  local expected_os="$1"
+  local current_os="$(uname -s)"
+
+  case "${expected_os}" in
+    linux)
+      if [[ "${current_os}" != "Linux" ]]; then
+        die "This script must be run on Linux. Detected: ${current_os}"
+      fi
+      ;;
+    darwin)
+      if [[ "${current_os}" != "Darwin" ]]; then
+        die "This script must be run on macOS. Detected: ${current_os}"
+      fi
+      ;;
+    windows)
+      if [[ "${current_os}" != MINGW* && "${current_os}" != MSYS* && "${current_os}" != CYGWIN* && "${current_os}" != "Windows_NT" ]]; then
+        die "This script must be run from PowerShell or Git Bash on Windows. Detected: ${current_os}"
+      fi
+      ;;
+  esac
+}

--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -40,6 +40,6 @@ ensure_rust_target "$TARGET"
 build_backend_sidecar "$TARGET"
 install_frontend_dependencies
 run_tauri_build "$TARGET"
-collect_release_artifacts
+collect_release_artifacts "$TARGET"
 
 info "Linux package build completed successfully."

--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/package-common.sh"
+
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/package-linux.sh [--target <triple>] [--help]
+
+Build the Linux desktop package for Markdown Reader using the same Tauri + PyInstaller
+steps as the GitHub Actions release workflow.
+
+Options:
+  --target <triple>  Override the Rust target triple (default: x86_64-unknown-linux-gnu)
+  --help             Show this message and exit
+EOF
+}
+
+TARGET="x86_64-unknown-linux-gnu"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target)
+      TARGET="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      die "Unknown option: $1"
+      ;;
+  esac
+done
+
+check_run_on_supported_platform linux
+prepare_linux_system_deps
+ensure_rust_target "$TARGET"
+build_backend_sidecar "$TARGET"
+install_frontend_dependencies
+run_tauri_build "$TARGET"
+collect_release_artifacts
+
+info "Linux package build completed successfully."

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -56,6 +56,6 @@ ensure_rust_target "$TARGET"
 build_backend_sidecar "$TARGET"
 install_frontend_dependencies
 run_tauri_build "$TARGET"
-collect_release_artifacts
+collect_release_artifacts "$TARGET"
 
 info "macOS package build completed successfully."

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/package-common.sh"
+
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/package-macos.sh [--target <triple>] [--help]
+
+Build the macOS desktop package for Markdown Reader using the same sidecar + Tauri
+workflow as the release pipeline.
+
+Options:
+  --target <triple>  Override the Rust target triple (default: detected architecture)
+  --help             Show this message and exit
+EOF
+}
+
+TARGET="${MARKDOWN_READER_TARGET:-}"
+if [[ -z "${TARGET}" ]]; then
+  case "$(uname -m)" in
+    arm64)
+      TARGET="aarch64-apple-darwin"
+      ;;
+    x86_64)
+      TARGET="x86_64-apple-darwin"
+      ;;
+    *)
+      die "Unsupported macOS architecture '$(uname -m)'. Supported values are arm64 and x86_64."
+      ;;
+  esac
+fi
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target)
+      TARGET="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      die "Unknown option: $1"
+      ;;
+  esac
+done
+
+check_run_on_supported_platform darwin
+if ! xcode-select -p >/dev/null 2>&1; then
+  die "Xcode Command Line Tools are required for macOS packaging. Run 'xcode-select --install' and retry."
+fi
+
+ensure_rust_target "$TARGET"
+build_backend_sidecar "$TARGET"
+install_frontend_dependencies
+run_tauri_build "$TARGET"
+collect_release_artifacts
+
+info "macOS package build completed successfully."

--- a/scripts/package-windows.ps1
+++ b/scripts/package-windows.ps1
@@ -73,13 +73,21 @@ $env:NEXT_EXPORT = "1"
 npx tauri build --target $Target
 
 Write-Host "==> Collecting packaged artifacts..."
-$bundleDir = Join-Path $frontend "src-tauri\target\release\bundle"
-if (Test-Path $bundleDir) {
-    New-Item -ItemType Directory -Force -Path $artifacts | Out-Null
-    Copy-Item (Join-Path $bundleDir "*") $artifacts -Recurse -Force
-    Write-Host "Done. Bundles are ready in $artifacts"
-} else {
-    throw "No Tauri bundle directory was found under $bundleDir. The build may have failed before producing artifacts."
+$targetBundleDir = Join-Path $frontend ("src-tauri\target\{0}\release\bundle" -f $Target)
+$nativeBundleDir = Join-Path $frontend "src-tauri\target\release\bundle"
+$bundleDir = @($targetBundleDir, $nativeBundleDir) |
+    Where-Object {
+        (Test-Path -LiteralPath $_ -PathType Container) -and
+        (@(Get-ChildItem -LiteralPath $_ -Force).Count -gt 0)
+    } |
+    Select-Object -First 1
+
+if (-not $bundleDir) {
+    throw "No packaged artifacts found for target $Target. Checked: $targetBundleDir and $nativeBundleDir"
 }
+
+New-Item -ItemType Directory -Force -Path $artifacts | Out-Null
+Copy-Item (Join-Path $bundleDir "*") $artifacts -Recurse -Force
+Write-Host "Done. Bundles are ready in $artifacts"
 
 Write-Host "Windows package build completed successfully."

--- a/scripts/package-windows.ps1
+++ b/scripts/package-windows.ps1
@@ -1,0 +1,85 @@
+param(
+    [string]$Target = "x86_64-pc-windows-msvc",
+    [switch]$Help
+)
+
+$ErrorActionPreference = "Stop"
+
+function Show-Usage {
+    @"
+Usage: ./scripts/package-windows.ps1 [-Target <triple>] [-Help]
+
+Build the Windows desktop package for Markdown Reader using the same sidecar + Tauri
+workflow as the GitHub Actions release job.
+
+Options:
+  -Target <triple>  Override the Rust target triple (default: x86_64-pc-windows-msvc)
+  -Help             Show this message and exit
+"@
+}
+
+if ($Help) {
+    Show-Usage
+    exit 0
+}
+
+$root = Split-Path -Parent $PSScriptRoot
+$frontend = Join-Path $root "frontend"
+$artifacts = Join-Path $root "release-artifacts"
+
+if (-not (Get-Command uv -ErrorAction SilentlyContinue)) {
+    throw "uv is required for packaging. Install it from https://docs.astral.sh/uv/ and retry."
+}
+
+if (-not (Get-Command node -ErrorAction SilentlyContinue) -or -not (Get-Command npm -ErrorAction SilentlyContinue)) {
+    throw "Node.js and npm are required for packaging. Install Node 20+ and retry."
+}
+
+if (-not (Get-Command cargo -ErrorAction SilentlyContinue)) {
+    throw "Rust is required for packaging. Install the Rust toolchain from https://rustup.rs and retry."
+}
+
+if (-not (rustup target list --installed | Select-String -SimpleMatch $Target)) {
+    Write-Host "==> Installing Rust target $Target..."
+    rustup target add $Target
+}
+
+Write-Host "==> Syncing Python dependencies with uv..."
+Set-Location $root
+uv sync --frozen
+
+Write-Host "==> Building backend sidecar with PyInstaller..."
+uv run pyinstaller markdown-reader-backend.spec
+
+$binaryDir = Join-Path $frontend "src-tauri\binaries"
+New-Item -ItemType Directory -Force -Path $binaryDir | Out-Null
+
+$source = Join-Path $root "dist\markdown-reader-backend.exe"
+if (-not (Test-Path $source)) {
+    throw "Backend build output not found at $source. The PyInstaller step failed."
+}
+
+$targetName = Join-Path $binaryDir ("markdown-reader-backend-{0}.exe" -f $Target)
+$defaultName = Join-Path $binaryDir "markdown-reader-backend.exe"
+Copy-Item $source $targetName -Force
+Copy-Item $source $defaultName -Force
+
+Write-Host "==> Installing frontend dependencies with npm ci..."
+Set-Location $frontend
+npm ci
+
+Write-Host "==> Building Tauri desktop bundle for target $Target..."
+$env:NEXT_EXPORT = "1"
+npx tauri build --target $Target
+
+Write-Host "==> Collecting packaged artifacts..."
+$bundleDir = Join-Path $frontend "src-tauri\target\release\bundle"
+if (Test-Path $bundleDir) {
+    New-Item -ItemType Directory -Force -Path $artifacts | Out-Null
+    Copy-Item (Join-Path $bundleDir "*") $artifacts -Recurse -Force
+    Write-Host "Done. Bundles are ready in $artifacts"
+} else {
+    throw "No Tauri bundle directory was found under $bundleDir. The build may have failed before producing artifacts."
+}
+
+Write-Host "Windows package build completed successfully."


### PR DESCRIPTION
## Summary

Adds platform-specific scripts for building Markdown Reader locally without relying on GitHub Actions.

## Changes

- Added Linux packaging script.
- Added macOS packaging script.
- Added Windows PowerShell packaging script.
- Added shared packaging helpers to avoid duplicating build logic.
- Automated Python sidecar compilation with PyInstaller.
- Automated frontend dependency installation and Tauri packaging.
- Added Linux dependency preparation where supported.
- Added artifact collection into `release-artifacts/`.
- Added clear validation and error messages.
- Documented local packaging commands in the README.

## Validation

- Bash syntax checks passed.
- Linux and macOS help commands passed.
- `git diff --check` passed.
- Full platform builds require the target platform and its native dependencies.

closes #237